### PR TITLE
Fixed Bug

### DIFF
--- a/Configuration.cs
+++ b/Configuration.cs
@@ -18,6 +18,7 @@ namespace LIGHT
         public bool LPXEnabled;
         public bool IncomeEnabled;
         public ushort IncomeInterval;
+        public string defaultUserGroup;
 
         public void LoadDefaults()
         {
@@ -27,6 +28,7 @@ namespace LIGHT
             DatabaseName = "unturned";
             DatabaseTableName = "LPX";
             DatabaseTableGroup = "LPXGroups";
+            defaultUserGroup = "default";
             DatabasePort = 3306;
             LPXEnabled = true;
             IncomeEnabled = true;

--- a/Database.cs
+++ b/Database.cs
@@ -271,6 +271,30 @@ namespace LIGHT
             }
 
         }
+        public void AddNewUserIntoGroup(string id, string group)
+        {
+            try
+            {
+                MySqlConnection connection = createConnection();
+                MySqlCommand command = connection.CreateCommand();
+                command.CommandText = "select `steamId` from `" + LIGHT.Instance.Configuration.Instance.DatabaseTableName + "` WHERE `steamId` = '" + id + "'";
+                connection.Open();
+                object result = command.ExecuteScalar();
+                connection.Close();
+                if (result == null)
+                {
+                    command.CommandText = "insert into `" + LIGHT.Instance.Configuration.Instance.DatabaseTableName + "` (`steamId`,`group`) values('" + id + "', '" + group + "')";
+                    connection.Open();
+                    command.ExecuteNonQuery();
+                    connection.Close();
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.LogException(ex);
+            }
+
+        }
         public bool AddGroup(string group, string income,string parentgroup, string updategroup, int Updatetime, bool autoUpdate)
         {
             decimal pay = decimal.Parse(income);

--- a/LIGHT.cs
+++ b/LIGHT.cs
@@ -9,7 +9,7 @@ using UnityEngine;
 using Rocket.Core;
 using Rocket.API;
 using SDG.Unturned;
-using unturned.ROCKS.Uconomy;   
+using fr34kyn01535.Uconomy; 
 using Steamworks;
 using System;
 using System.Collections.Generic;

--- a/LIGHT.cs
+++ b/LIGHT.cs
@@ -114,6 +114,7 @@ namespace LIGHT
 
         public void RocketServerEvents_OnPlayerConnected(UnturnedPlayer player)
         {
+            LIGHT.Instance.Database.AddNewUserIntoGroup(player.Id, Configuration.Instance.defaultUserGroup);
             string[] permission = { };
             string[] cmd = {};
             permission = LIGHT.Instance.Database.getPermission(player.Id);

--- a/LIGHT.csproj
+++ b/LIGHT.csproj
@@ -63,7 +63,7 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="Uconomy">
-      <HintPath>lib\Uconomy.dll</HintPath>
+      <HintPath>..\..\..\..\..\gameservers\Unturned Server\Servers\ChamCraft\Rocket\Plugins\Uconomy.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine">
       <HintPath>lib\UnityEngine.dll</HintPath>

--- a/PlayerUE.cs
+++ b/PlayerUE.cs
@@ -2,7 +2,7 @@
 using Rocket.Unturned.Player;
 using Rocket.Unturned.Chat;
 using Rocket.Core.Logging;
-using unturned.ROCKS.Uconomy;
+using fr34kyn01535.Uconomy;
 using System.Data;
 using System.Collections.Generic;
 


### PR DESCRIPTION
Fixed bug where console would spam "unturned.rocks.uconomy.uconomy"
repeatedly. (Compiled against latest version of Uconomy, replaced
'unturned.ROCKS.uconomy' with 'fr34ky0ne.uconomy')

Plugin did not insert user into database when they joined for the first
time, leaving the player in a "limbo" state until an admin manually adds
them.

Also added "DefaultUserGroup" to the config in case your default user
group is named something other than default.
